### PR TITLE
Removed old wiki link in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ I gladly accept pull requests to Leek Wars. Before starting work on a feature, s
 - Twitter : https://twitter.com/LeekWars
 - Facebook : https://www.facebook.com/LeekWars/
 - GitHub (this repo) : https://github.com/leek-wars/leek-wars
-- Wiki : http://leekwarswiki.net
 
 ## License
 


### PR DESCRIPTION
Le readme avais un lien vers l'ancien wiki, qui n'est maintenant plus disponible, ayant été remplacé par le wiki in game.